### PR TITLE
updates package.json with npm start script for AWS EB deployment

### DIFF
--- a/client/acorn
+++ b/client/acorn
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/acorn/bin/acorn" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/acorn/bin/acorn" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/acorn.cmd
+++ b/client/acorn.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\acorn\bin\acorn" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/acorn.ps1
+++ b/client/acorn.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/acorn/bin/acorn" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/acorn/bin/acorn" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/ansi-html
+++ b/client/ansi-html
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/ansi-html/bin/ansi-html" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/ansi-html/bin/ansi-html" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/ansi-html.cmd
+++ b/client/ansi-html.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\ansi-html\bin\ansi-html" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/ansi-html.ps1
+++ b/client/ansi-html.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/ansi-html/bin/ansi-html" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/ansi-html/bin/ansi-html" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/atob
+++ b/client/atob
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/atob/bin/atob.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/atob/bin/atob.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/atob.cmd
+++ b/client/atob.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\atob\bin\atob.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/atob.ps1
+++ b/client/atob.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/atob/bin/atob.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/atob/bin/atob.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/autoprefixer
+++ b/client/autoprefixer
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/autoprefixer/bin/autoprefixer" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/autoprefixer/bin/autoprefixer" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/autoprefixer.cmd
+++ b/client/autoprefixer.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\autoprefixer\bin\autoprefixer" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/autoprefixer.ps1
+++ b/client/autoprefixer.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/autoprefixer/bin/autoprefixer" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/autoprefixer/bin/autoprefixer" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/babylon
+++ b/client/babylon
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/babylon/bin/babylon.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/babylon/bin/babylon.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/babylon.cmd
+++ b/client/babylon.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\babylon\bin\babylon.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/babylon.ps1
+++ b/client/babylon.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/babylon/bin/babylon.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/babylon/bin/babylon.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/browserslist
+++ b/client/browserslist
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/browserslist/cli.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/browserslist/cli.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/browserslist.cmd
+++ b/client/browserslist.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\browserslist\cli.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/browserslist.ps1
+++ b/client/browserslist.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/browserslist/cli.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/browserslist/cli.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/css-blank-pseudo
+++ b/client/css-blank-pseudo
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/css-blank-pseudo/cli.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/css-blank-pseudo/cli.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/css-blank-pseudo.cmd
+++ b/client/css-blank-pseudo.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\css-blank-pseudo\cli.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/css-blank-pseudo.ps1
+++ b/client/css-blank-pseudo.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/css-blank-pseudo/cli.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/css-blank-pseudo/cli.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/css-has-pseudo
+++ b/client/css-has-pseudo
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/css-has-pseudo/cli.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/css-has-pseudo/cli.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/css-has-pseudo.cmd
+++ b/client/css-has-pseudo.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\css-has-pseudo\cli.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/css-has-pseudo.ps1
+++ b/client/css-has-pseudo.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/css-has-pseudo/cli.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/css-has-pseudo/cli.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/css-prefers-color-scheme
+++ b/client/css-prefers-color-scheme
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/css-prefers-color-scheme/cli.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/css-prefers-color-scheme/cli.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/css-prefers-color-scheme.cmd
+++ b/client/css-prefers-color-scheme.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\css-prefers-color-scheme\cli.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/css-prefers-color-scheme.ps1
+++ b/client/css-prefers-color-scheme.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/css-prefers-color-scheme/cli.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/css-prefers-color-scheme/cli.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/cssesc
+++ b/client/cssesc
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/cssesc/bin/cssesc" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/cssesc/bin/cssesc" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/cssesc.cmd
+++ b/client/cssesc.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\cssesc\bin\cssesc" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/cssesc.ps1
+++ b/client/cssesc.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/cssesc/bin/cssesc" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/cssesc/bin/cssesc" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/detect
+++ b/client/detect
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/detect-port-alt/bin/detect-port" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/detect-port-alt/bin/detect-port" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/detect-port
+++ b/client/detect-port
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/detect-port-alt/bin/detect-port" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/detect-port-alt/bin/detect-port" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/detect-port.cmd
+++ b/client/detect-port.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\detect-port-alt\bin\detect-port" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/detect-port.ps1
+++ b/client/detect-port.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/detect-port-alt/bin/detect-port" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/detect-port-alt/bin/detect-port" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/detect.cmd
+++ b/client/detect.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\detect-port-alt\bin\detect-port" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/detect.ps1
+++ b/client/detect.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/detect-port-alt/bin/detect-port" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/detect-port-alt/bin/detect-port" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/errno
+++ b/client/errno
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/errno/cli.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/errno/cli.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/errno.cmd
+++ b/client/errno.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\errno\cli.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/errno.ps1
+++ b/client/errno.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/errno/cli.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/errno/cli.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/escodegen
+++ b/client/escodegen
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/escodegen/bin/escodegen.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/escodegen/bin/escodegen.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/escodegen.cmd
+++ b/client/escodegen.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\escodegen\bin\escodegen.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/escodegen.ps1
+++ b/client/escodegen.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/escodegen/bin/escodegen.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/escodegen/bin/escodegen.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/esgenerate
+++ b/client/esgenerate
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/escodegen/bin/esgenerate.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/escodegen/bin/esgenerate.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/esgenerate.cmd
+++ b/client/esgenerate.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\escodegen\bin\esgenerate.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/esgenerate.ps1
+++ b/client/esgenerate.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/escodegen/bin/esgenerate.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/escodegen/bin/esgenerate.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/eslint
+++ b/client/eslint
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/eslint/bin/eslint.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/eslint/bin/eslint.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/eslint.cmd
+++ b/client/eslint.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\eslint\bin\eslint.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/eslint.ps1
+++ b/client/eslint.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/eslint/bin/eslint.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/eslint/bin/eslint.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/esparse
+++ b/client/esparse
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/esprima/bin/esparse.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/esprima/bin/esparse.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/esparse.cmd
+++ b/client/esparse.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\esprima\bin\esparse.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/esparse.ps1
+++ b/client/esparse.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/esprima/bin/esparse.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/esprima/bin/esparse.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/esvalidate
+++ b/client/esvalidate
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/esprima/bin/esvalidate.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/esprima/bin/esvalidate.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/esvalidate.cmd
+++ b/client/esvalidate.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\esprima\bin\esvalidate.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/esvalidate.ps1
+++ b/client/esvalidate.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/esprima/bin/esvalidate.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/esprima/bin/esvalidate.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/he
+++ b/client/he
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/he/bin/he" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/he/bin/he" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/he.cmd
+++ b/client/he.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\he\bin\he" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/he.ps1
+++ b/client/he.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/he/bin/he" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/he/bin/he" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/html-minifier-terser
+++ b/client/html-minifier-terser
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/html-minifier-terser/cli.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/html-minifier-terser/cli.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/html-minifier-terser.cmd
+++ b/client/html-minifier-terser.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\html-minifier-terser\cli.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/html-minifier-terser.ps1
+++ b/client/html-minifier-terser.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/html-minifier-terser/cli.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/html-minifier-terser/cli.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/import-local-fixture
+++ b/client/import-local-fixture
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/import-local/fixtures/cli.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/import-local/fixtures/cli.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/import-local-fixture.cmd
+++ b/client/import-local-fixture.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\import-local\fixtures\cli.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/import-local-fixture.ps1
+++ b/client/import-local-fixture.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/import-local/fixtures/cli.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/import-local/fixtures/cli.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/is-ci
+++ b/client/is-ci
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/is-ci/bin.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/is-ci/bin.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/is-ci.cmd
+++ b/client/is-ci.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\is-ci\bin.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/is-ci.ps1
+++ b/client/is-ci.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/is-ci/bin.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/is-ci/bin.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/jest
+++ b/client/jest
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/jest/bin/jest.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/jest/bin/jest.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/jest-runtime
+++ b/client/jest-runtime
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/jest-runtime/bin/jest-runtime.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/jest-runtime/bin/jest-runtime.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/jest-runtime.cmd
+++ b/client/jest-runtime.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\jest-runtime\bin\jest-runtime.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/jest-runtime.ps1
+++ b/client/jest-runtime.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/jest-runtime/bin/jest-runtime.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/jest-runtime/bin/jest-runtime.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/jest.cmd
+++ b/client/jest.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\jest\bin\jest.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/jest.ps1
+++ b/client/jest.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/jest/bin/jest.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/jest/bin/jest.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/js-yaml
+++ b/client/js-yaml
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/js-yaml/bin/js-yaml.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/js-yaml/bin/js-yaml.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/js-yaml.cmd
+++ b/client/js-yaml.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\js-yaml\bin\js-yaml.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/js-yaml.ps1
+++ b/client/js-yaml.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/js-yaml/bin/js-yaml.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/js-yaml/bin/js-yaml.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/jsesc
+++ b/client/jsesc
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/jsesc/bin/jsesc" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/jsesc/bin/jsesc" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/jsesc.cmd
+++ b/client/jsesc.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\jsesc\bin\jsesc" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/jsesc.ps1
+++ b/client/jsesc.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/jsesc/bin/jsesc" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/jsesc/bin/jsesc" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/json5
+++ b/client/json5
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/json5/lib/cli.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/json5/lib/cli.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/json5.cmd
+++ b/client/json5.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\json5\lib\cli.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/json5.ps1
+++ b/client/json5.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/json5/lib/cli.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/json5/lib/cli.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/loose-envify
+++ b/client/loose-envify
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/loose-envify/cli.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/loose-envify/cli.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/loose-envify.cmd
+++ b/client/loose-envify.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\loose-envify\cli.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/loose-envify.ps1
+++ b/client/loose-envify.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/loose-envify/cli.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/loose-envify/cli.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/miller-rabin
+++ b/client/miller-rabin
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/miller-rabin/bin/miller-rabin" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/miller-rabin/bin/miller-rabin" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/miller-rabin.cmd
+++ b/client/miller-rabin.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\miller-rabin\bin\miller-rabin" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/miller-rabin.ps1
+++ b/client/miller-rabin.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/miller-rabin/bin/miller-rabin" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/miller-rabin/bin/miller-rabin" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/mime
+++ b/client/mime
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/mime/cli.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/mime/cli.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/mime.cmd
+++ b/client/mime.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\mime\cli.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/mime.ps1
+++ b/client/mime.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/mime/cli.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/mime/cli.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/mkdirp
+++ b/client/mkdirp
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/mkdirp/bin/cmd.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/mkdirp/bin/cmd.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/mkdirp.cmd
+++ b/client/mkdirp.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\mkdirp\bin\cmd.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/mkdirp.ps1
+++ b/client/mkdirp.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/mkdirp/bin/cmd.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/mkdirp/bin/cmd.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/multicast-dns
+++ b/client/multicast-dns
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/multicast-dns/cli.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/multicast-dns/cli.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/multicast-dns.cmd
+++ b/client/multicast-dns.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\multicast-dns\cli.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/multicast-dns.ps1
+++ b/client/multicast-dns.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/multicast-dns/cli.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/multicast-dns/cli.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/parser
+++ b/client/parser
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/@babel/parser/bin/babel-parser.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/@babel/parser/bin/babel-parser.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/parser.cmd
+++ b/client/parser.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\@babel\parser\bin\babel-parser.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/parser.ps1
+++ b/client/parser.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/@babel/parser/bin/babel-parser.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/@babel/parser/bin/babel-parser.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/react-scripts
+++ b/client/react-scripts
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/react-scripts/bin/react-scripts.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/react-scripts/bin/react-scripts.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/react-scripts.cmd
+++ b/client/react-scripts.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\react-scripts\bin\react-scripts.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/react-scripts.ps1
+++ b/client/react-scripts.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/react-scripts/bin/react-scripts.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/react-scripts/bin/react-scripts.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/regjsparser
+++ b/client/regjsparser
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/regjsparser/bin/parser" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/regjsparser/bin/parser" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/regjsparser.cmd
+++ b/client/regjsparser.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\regjsparser\bin\parser" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/regjsparser.ps1
+++ b/client/regjsparser.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/regjsparser/bin/parser" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/regjsparser/bin/parser" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/rimraf
+++ b/client/rimraf
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/rimraf/bin.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/rimraf/bin.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/rimraf.cmd
+++ b/client/rimraf.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\rimraf\bin.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/rimraf.ps1
+++ b/client/rimraf.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/rimraf/bin.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/rimraf/bin.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/sane
+++ b/client/sane
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/sane/src/cli.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/sane/src/cli.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/sane.cmd
+++ b/client/sane.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\sane\src\cli.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/sane.ps1
+++ b/client/sane.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/sane/src/cli.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/sane/src/cli.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/semver
+++ b/client/semver
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/semver/bin/semver.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/semver/bin/semver.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/semver.cmd
+++ b/client/semver.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\semver\bin\semver.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/semver.ps1
+++ b/client/semver.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/semver/bin/semver.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/semver/bin/semver.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/sha.js
+++ b/client/sha.js
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/sha.js/bin.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/sha.js/bin.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/sha.js.cmd
+++ b/client/sha.js.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\sha.js\bin.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/sha.js.ps1
+++ b/client/sha.js.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/sha.js/bin.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/sha.js/bin.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/sshpk-conv
+++ b/client/sshpk-conv
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/sshpk/bin/sshpk-conv" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/sshpk/bin/sshpk-conv" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/sshpk-conv.cmd
+++ b/client/sshpk-conv.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\sshpk\bin\sshpk-conv" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/sshpk-conv.ps1
+++ b/client/sshpk-conv.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/sshpk/bin/sshpk-conv" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/sshpk/bin/sshpk-conv" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/sshpk-sign
+++ b/client/sshpk-sign
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/sshpk/bin/sshpk-sign" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/sshpk/bin/sshpk-sign" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/sshpk-sign.cmd
+++ b/client/sshpk-sign.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\sshpk\bin\sshpk-sign" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/sshpk-sign.ps1
+++ b/client/sshpk-sign.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/sshpk/bin/sshpk-sign" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/sshpk/bin/sshpk-sign" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/sshpk-verify
+++ b/client/sshpk-verify
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/sshpk/bin/sshpk-verify" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/sshpk/bin/sshpk-verify" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/sshpk-verify.cmd
+++ b/client/sshpk-verify.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\sshpk\bin\sshpk-verify" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/sshpk-verify.ps1
+++ b/client/sshpk-verify.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/sshpk/bin/sshpk-verify" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/sshpk/bin/sshpk-verify" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/svgo
+++ b/client/svgo
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/svgo/bin/svgo" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/svgo/bin/svgo" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/svgo.cmd
+++ b/client/svgo.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\svgo\bin\svgo" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/svgo.ps1
+++ b/client/svgo.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/svgo/bin/svgo" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/svgo/bin/svgo" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/terser
+++ b/client/terser
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/terser/bin/terser" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/terser/bin/terser" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/terser.cmd
+++ b/client/terser.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\terser\bin\terser" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/terser.ps1
+++ b/client/terser.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/terser/bin/terser" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/terser/bin/terser" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/uuid
+++ b/client/uuid
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/uuid/bin/uuid" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/uuid/bin/uuid" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/uuid.cmd
+++ b/client/uuid.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\uuid\bin\uuid" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/uuid.ps1
+++ b/client/uuid.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/uuid/bin/uuid" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/uuid/bin/uuid" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/watch
+++ b/client/watch
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/@cnakazawa/watch/cli.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/@cnakazawa/watch/cli.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/watch.cmd
+++ b/client/watch.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\@cnakazawa\watch\cli.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/watch.ps1
+++ b/client/watch.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/@cnakazawa/watch/cli.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/@cnakazawa/watch/cli.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/webpack
+++ b/client/webpack
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/webpack/bin/webpack.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/webpack/bin/webpack.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/webpack-dev-server
+++ b/client/webpack-dev-server
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/webpack-dev-server/bin/webpack-dev-server.js" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/webpack-dev-server/bin/webpack-dev-server.js" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/webpack-dev-server.cmd
+++ b/client/webpack-dev-server.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\webpack-dev-server\bin\webpack-dev-server.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/webpack-dev-server.ps1
+++ b/client/webpack-dev-server.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/webpack-dev-server/bin/webpack-dev-server.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/webpack-dev-server/bin/webpack-dev-server.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/webpack.cmd
+++ b/client/webpack.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\webpack\bin\webpack.js" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/webpack.ps1
+++ b/client/webpack.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/webpack/bin/webpack.js" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/webpack/bin/webpack.js" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/client/which
+++ b/client/which
@@ -1,0 +1,15 @@
+#!/bin/sh
+basedir=$(dirname "$(echo "$0" | sed -e 's,\\,/,g')")
+
+case `uname` in
+    *CYGWIN*|*MINGW*|*MSYS*) basedir=`cygpath -w "$basedir"`;;
+esac
+
+if [ -x "$basedir/node" ]; then
+  "$basedir/node"  "$basedir/node_modules/which/bin/which" "$@"
+  ret=$?
+else 
+  node  "$basedir/node_modules/which/bin/which" "$@"
+  ret=$?
+fi
+exit $ret

--- a/client/which.cmd
+++ b/client/which.cmd
@@ -1,0 +1,17 @@
+@ECHO off
+SETLOCAL
+CALL :find_dp0
+
+IF EXIST "%dp0%\node.exe" (
+  SET "_prog=%dp0%\node.exe"
+) ELSE (
+  SET "_prog=node"
+  SET PATHEXT=%PATHEXT:;.JS;=;%
+)
+
+"%_prog%"  "%dp0%\node_modules\which\bin\which" %*
+ENDLOCAL
+EXIT /b %errorlevel%
+:find_dp0
+SET dp0=%~dp0
+EXIT /b

--- a/client/which.ps1
+++ b/client/which.ps1
@@ -1,0 +1,18 @@
+#!/usr/bin/env pwsh
+$basedir=Split-Path $MyInvocation.MyCommand.Definition -Parent
+
+$exe=""
+if ($PSVersionTable.PSVersion -lt "6.0" -or $IsWindows) {
+  # Fix case when both the Windows and Linux builds of Node
+  # are installed in the same directory
+  $exe=".exe"
+}
+$ret=0
+if (Test-Path "$basedir/node$exe") {
+  & "$basedir/node$exe"  "$basedir/node_modules/which/bin/which" $args
+  $ret=$LASTEXITCODE
+} else {
+  & "node$exe"  "$basedir/node_modules/which/bin/which" $args
+  $ret=$LASTEXITCODE
+}
+exit $ret

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "client-install": "npm install --prefix client",
     "deploy": "npm run build --prefix client && git add -A && git commit -m 'deployment ready' && git push origin HEAD",
+    "start": "node server.js",
     "server": "nodemon --exec babel-node server.js",
     "client": "npm start --prefix client",
     "dev": "concurrently --kill-others \"npm run server\" \"npm run client\""


### PR DESCRIPTION
# Description

AWS Elastic Beanstalk requires the `npm start` script in order to deploy and start the application. This PR adds the script back to the package.json file.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Fixes breaking change

# Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
